### PR TITLE
Flask deprecated "before_first_request" which is used in  __init__.py

### DIFF
--- a/gnucash_rest/__init__.py
+++ b/gnucash_rest/__init__.py
@@ -99,8 +99,9 @@ session = None
 app = Flask(__name__)
 
 
-@app.before_first_request
+@app.before_request
 def _run_on_start():
+    app.before_request_funcs[None].remove(_run_on_start)
     startup()
     # register method to close gnucash connection gracefully
     atexit.register(shutdown)


### PR DESCRIPTION
Replaced before_first_request with fix from:

https://stackoverflow.com/questions/73570041/flask-deprecated-before-first-request-how-to-update